### PR TITLE
Automatically build the image, remove lockfile-changed as an option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,12 @@ jobs:
         run: cargo build
 
       - name: Formatting
-        run: cargo fmt --check
+        run: |
+          cargo fmt --check
+          cargo clippy -- -Dclippy::all
 
       - name: Run
         run: |
-          docker build docker/ -t miri:latest < docker/Dockerfile
-          cargo run -- --crates=1
+          cargo run -- --crates=10
+          cargo run --bin render
+          cargo run --bin uploader -- --help

--- a/src/bin/render.rs
+++ b/src/bin/render.rs
@@ -81,7 +81,7 @@ function scroll_to_ub() {{
 }
 
 fn write_crate_output(krate: &Crate, output: &str) -> Result<()> {
-    let encoded = ansi_to_html::convert_escaped(&output);
+    let encoded = ansi_to_html::convert_escaped(output);
 
     let encoded = encoded.replacen(
         "Undefined Behavior:",

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
                 known += 1;
             }
             Status::Error(err) => {
-                *errored.entry(&err).or_default() += 1;
+                *errored.entry(err).or_default() += 1;
                 known += 1;
             }
             Status::UB { cause: causes, .. } => {

--- a/src/diagnose.rs
+++ b/src/diagnose.rs
@@ -115,18 +115,18 @@ fn diagnose_output(output: &str) -> Vec<Cause> {
         for line in &lines[l..] {
             if line.contains("inside `") && line.contains(" at ") {
                 let path = line.split(" at ").nth(1).unwrap();
-                if path.contains("/root/build") || !path.starts_with("/") {
+                if path.contains("/root/build") || !path.starts_with('/') {
                     break;
                 } else if path.contains("/root/.cargo/registry/src/") {
                     let crate_name = path
                         .split("/root/.cargo/registry/src/github.com-1ecc6299db9ec823/")
                         .nth(1)
                         .unwrap()
-                        .split("/")
-                        .nth(0)
+                        .split('/')
+                        .next()
                         .unwrap();
 
-                    source_crate = Some(format!("{}", crate_name));
+                    source_crate = Some(crate_name.to_string());
                     break;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
-use backoff::{retry, ExponentialBackoff};
 use clap::Parser;
 use color_eyre::eyre::Result;
 use indicatif::{HumanDuration, ProgressBar, ProgressStyle};
-use miri_the_world::{db_dump, Crate, Error, Version};
+use miri_the_world::{db_dump, Crate, Version};
 use rayon::prelude::*;
 use std::{
     collections::HashMap,
     fmt,
     fs::{self, File},
     io::{BufRead, BufReader, Write},
+    path::Path,
     process::Stdio,
     str::FromStr,
     sync::{Arc, Mutex},
@@ -32,7 +32,7 @@ struct Args {
     #[clap(long)]
     jobs: Option<usize>,
 
-    #[clap(long, default_value_t = RerunWhen::LockfileChanged)]
+    #[clap(long, default_value_t = RerunWhen::Never)]
     rerun_when: RerunWhen,
 }
 
@@ -40,7 +40,6 @@ struct Args {
 enum RerunWhen {
     Always,
     Never,
-    LockfileChanged,
 }
 
 impl FromStr for RerunWhen {
@@ -50,7 +49,6 @@ impl FromStr for RerunWhen {
         match s {
             "always" => Ok(RerunWhen::Always),
             "never" => Ok(RerunWhen::Never),
-            "lockfile-changed" => Ok(RerunWhen::LockfileChanged),
             _ => Err("invalid rerun-when option"),
         }
     }
@@ -64,7 +62,6 @@ impl fmt::Display for RerunWhen {
             match self {
                 RerunWhen::Always => "always",
                 RerunWhen::Never => "never",
-                RerunWhen::LockfileChanged => "lockfile-changed",
             }
         )
     }
@@ -85,7 +82,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     let status = std::process::Command::new("docker")
-        .args(&["build", "-t", DOCKER_TAG, "docker/"])
+        .args(["build", "-t", DOCKER_TAG, "docker/"])
         .stdin(File::open("docker/Dockerfile")?)
         .output()?;
     color_eyre::eyre::ensure!(
@@ -95,7 +92,7 @@ fn main() -> Result<()> {
 
     let all_crates = db_dump::download()?;
     let crates = if let Some(crate_count) = args.crates {
-        let mut crates = all_crates.clone();
+        let mut crates = all_crates;
         crates.truncate(crate_count);
         crates
     } else {
@@ -105,13 +102,15 @@ fn main() -> Result<()> {
             .map(|c| (c.name.clone(), c))
             .collect();
         let mut crates = Vec::new();
-        for line in crate_list.trim().split_whitespace() {
+        for line in crate_list.split_whitespace() {
             let mut it = line.split("==");
             let name = it.next().unwrap();
             let version = it.next();
             if let Some(c) = all_crates.get(name) {
                 crates.push(Crate {
-                    version: version.map(Version::parse).unwrap_or(c.version.clone()),
+                    version: version
+                        .map(Version::parse)
+                        .unwrap_or_else(|| c.version.clone()),
                     ..c.clone()
                 });
             }
@@ -148,75 +147,14 @@ fn main() -> Result<()> {
     let crates = crates
         .into_par_iter()
         .filter(|krate| {
-            // Keep all crates if rerun-when=always
-            if let RerunWhen::Always = args.rerun_when {
-                return true;
-            }
-
-            if let Ok(contents) =
-                fs::read_to_string(format!("logs/{}/{}", krate.name, krate.version))
-            {
-                // Skip crates if a log exists and rerun-when=never
-                if let RerunWhen::Never = args.rerun_when {
-                    bar.inc(1);
-                    return false;
+            let should_run = match args.rerun_when {
+                RerunWhen::Always => true,
+                RerunWhen::Never => {
+                    !Path::new(&format!("logs/{}/{}", krate.name, krate.version)).exists()
                 }
-
-                let previous_lockfile = contents.rsplit("cat Cargo.lock\r\n").nth(0).unwrap();
-                let previous_lockfile = previous_lockfile.replace("\r\n", "\n");
-
-                let dir = tempfile::tempdir().unwrap();
-
-                let backoff = ExponentialBackoff::default();
-                if let Err(e) = retry(backoff, || {
-                    krate.fetch_into(dir.path()).map_err(|e| {
-                        // Yanked crates return a 403, retrying those is a mistake
-                        if let Error::Net(ureq::Error::Status(403, _)) = e {
-                            backoff::Error::permanent(e)
-                        } else {
-                            backoff::Error::transient(e)
-                        }
-                    })
-                }) {
-                    bar.println(&format!("{:?}", e));
-                    bar.inc(1);
-                    return true;
-                }
-
-                let res = std::process::Command::new("cargo")
-                    .args(&[
-                        "+nightly",
-                        "update",
-                        &format!(
-                            "--manifest-path={}",
-                            dir.path().join("Cargo.toml").display()
-                        ),
-                        "-Zno-index-update",
-                    ])
-                    .output()
-                    .unwrap();
-
-                let new_lockfile = if res.status.success() {
-                    std::fs::read_to_string(dir.path().join("Cargo.lock")).unwrap()
-                } else {
-                    bar.println(&format!(
-                        "Error when generating lockfile for {} {} {}",
-                        krate.name,
-                        krate.version,
-                        String::from_utf8_lossy(&res.stderr)
-                    ));
-                    bar.inc(1);
-                    return true;
-                };
-
-                if new_lockfile == previous_lockfile {
-                    bar.inc(1);
-                    return false;
-                }
-            }
-
+            };
             bar.inc(1);
-            true
+            should_run
         })
         .collect::<Vec<_>>();
     bar.finish();
@@ -278,7 +216,7 @@ fn main() -> Result<()> {
             bar.println(format!("Finished {} {}", krate.name, krate.version));
 
             if let Ok(Some(_)) = child.try_wait() {
-                bar.println(format!("A worker crashed! Standing up a new one..."));
+                bar.println("A worker crashed! Standing up a new one...");
                 child = spawn_worker(&args, &test_end_delimiter);
             }
         });
@@ -299,7 +237,7 @@ fn spawn_worker(args: &Args, test_end_delimiter: &str) -> std::process::Child {
                      -Zmiri-panic-on-unsupported -Zmiri-retag-fields=scalar";
 
     std::process::Command::new("docker")
-        .args(&[
+        .args([
             "run",
             "--rm",
             "--interactive",


### PR DESCRIPTION
Building the image is a rake everyone steps on when picking this project up.

I originally added `--rerun-when=lockfile-changed` under the idea that this could run forever as a daemon, and clear crates from the UB list when a dependency publishes a fix. This option turns out to be useless in practice because crates that appear in every lockfile like libc publish new versions often.