### PR TITLE
Don't output the Cargo.lock

### DIFF
--- a/docker/run-asan.sh
+++ b/docker/run-asan.sh
@@ -12,7 +12,6 @@ do
         cargo +nightly update --color=always
         cargo +nightly careful test --no-run --color=always $ARGS
         unbuffer -p /usr/bin/time -v cargo +nightly careful test --no-fail-fast -- --test-threads=2 $ARGS
-        cat Cargo.lock
     fi
     echo "-${TEST_END_DELIMITER}-"
 done < /dev/stdin

--- a/docker/run-miri.sh
+++ b/docker/run-miri.sh
@@ -13,7 +13,6 @@ do
         cargo +miri miri test --no-run --color=always --jobs=1 $ARGS
         MIRIFLAGS="$MIRIFLAGS --color=always" unbuffer -p /usr/bin/time -v cargo +miri miri nextest run --color=always --no-fail-fast --config-file=/root/.cargo/nextest.toml --jobs=1 $ARGS
         unbuffer -p /usr/bin/time -v cargo +miri miri test --doc --no-fail-fast --jobs=1 $ARGS
-        cat Cargo.lock
     fi
     echo "-${TEST_END_DELIMITER}-"
 done < /dev/stdin


### PR DESCRIPTION
Originally the plan here was to re-run a crate's test suite when anything in the lockfile was updated, but it turns out that some crates like `serde` and friends or `libc` make small releases all the time and bump the majority of lockfiles in the ecosystem. Which generates a lot of useless lockfile updates.

Beyond that, this _looks_ useful for reproducability, but I have never needed it for that. Changes to Miri are the only source of disruption, and lockfiles cannot help there.

So all this did was add noise to the bottom of logs. No thanks. Bye.