### PR TITLE
Don't wrap test runs in /usr/bin/time -v

### DIFF
--- a/docker/run-asan.sh
+++ b/docker/run-asan.sh
@@ -11,7 +11,7 @@ do
         ARGS=$(python3 /root/get-args.py $crate)
         cargo +nightly update --color=always
         cargo +nightly careful test --no-run --color=always $ARGS
-        unbuffer -p /usr/bin/time -v cargo +nightly careful test --no-fail-fast -- --test-threads=2 $ARGS
+        unbuffer -p cargo +nightly careful test --no-fail-fast -- --test-threads=2 $ARGS
     fi
     echo "-${TEST_END_DELIMITER}-"
 done < /dev/stdin

--- a/docker/run-miri.sh
+++ b/docker/run-miri.sh
@@ -11,8 +11,8 @@ do
         ARGS=$(python3 /root/get-args.py $crate)
         cargo +miri update --color=always
         cargo +miri miri test --no-run --color=always --jobs=1 $ARGS
-        MIRIFLAGS="$MIRIFLAGS --color=always" unbuffer -p /usr/bin/time -v cargo +miri miri nextest run --color=always --no-fail-fast --config-file=/root/.cargo/nextest.toml --jobs=1 $ARGS
-        unbuffer -p /usr/bin/time -v cargo +miri miri test --doc --no-fail-fast --jobs=1 $ARGS
+        MIRIFLAGS="$MIRIFLAGS --color=always" unbuffer -p cargo +miri miri nextest run --color=always --no-fail-fast --config-file=/root/.cargo/nextest.toml --jobs=1 $ARGS
+        unbuffer -p cargo +miri miri test --doc --no-fail-fast --jobs=1 $ARGS
     fi
     echo "-${TEST_END_DELIMITER}-"
 done < /dev/stdin


### PR DESCRIPTION
Same argument as https://github.com/saethlin/miri-tools/pull/26 with the extra detail that we could do this better from the Rust program that's causing these to run.