### PR TITLE
Include the crate name and version at the top of each page

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -30,8 +30,9 @@ function scroll_to_ub() {{
     }}
 }}
 </script>
-<body onload="scroll_to_ub()"><pre>
-{}</pre></body></html>"#
+<body onload="scroll_to_ub()">
+<pre style="text-align: center;">{} {}</pre>
+<pre>{}</pre></body></html>"#
     }
 }
 
@@ -57,7 +58,10 @@ pub fn render_crate(krate: &Crate, output: &str) -> String {
         }
     }
 
-    format!(log_format!(), css, krate.name, krate.version, encoded)
+    format!(
+        log_format!(),
+        css, krate.name, krate.version, krate.name, krate.version, encoded
+    )
 }
 
 const OUTPUT_HEADER: &str = r#"<!DOCTYPE HTML>


### PR DESCRIPTION
Closes https://github.com/saethlin/miri-tools/issues/14 (crudely)

It might be nice to have this in some kind of `position: fixed; top: 0` div but that raises a bunch of other questions about scrolling. That's too complicated for now.