### PR TITLE
Log the name/version of crates during rendering issues

### DIFF
--- a/ansi-to-html/src/lib.rs
+++ b/ansi-to-html/src/lib.rs
@@ -4,8 +4,8 @@ mod renderer;
 
 use renderer::Renderer;
 
-pub fn convert_escaped(ansi: &str) -> (String, String) {
-    let mut renderer = Renderer::default();
+pub fn convert_escaped(name: String, ansi: &str) -> (String, String) {
+    let mut renderer = Renderer::new(name.clone());
     let mut parser = vte::Parser::new();
     for byte in ansi.as_bytes() {
         parser.advance(&mut renderer, *byte);

--- a/ansi-to-html/src/perform.rs
+++ b/ansi-to-html/src/perform.rs
@@ -21,7 +21,7 @@ impl Perform for Renderer {
             //C0::SI => self.set_active_charset(CharsetIndex::G0),
             //C0::SO => self.set_active_charset(CharsetIndex::G1),
             _ => {
-                log::warn!("Unhandled execute byte={:02x}", byte)
+                log::warn!("Unhandled execute byte={:02x} in {:?}", byte, self.name)
             }
         }
     }
@@ -80,7 +80,7 @@ impl Perform for Renderer {
                         if let Some(color) = parse_color(&mut it) {
                             self.foreground = color;
                         } else {
-                            log::warn!("Unhandled m 48: {:?}", params);
+                            log::warn!("Unhandled m 48: {:?} in {:?}", params, self.name);
                         }
                     }
                     &[39] => self.foreground = Color::bright_white(), // Default foreground color
@@ -96,7 +96,7 @@ impl Perform for Renderer {
                         if let Some(color) = parse_color(&mut it) {
                             self.background = color;
                         } else {
-                            log::warn!("Unhandled m 48: {:?}", params);
+                            log::warn!("Unhandled m 48: {:?} in {:?}", params, self.name);
                         }
                     }
                     &[49] => self.background = Color::black(), // Default foreground color
@@ -119,7 +119,7 @@ impl Perform for Renderer {
                     &[107] => self.background = Color::bright_white(),
 
                     _ => {
-                        log::warn!("Unhandled m with unknown start: {:?}", params)
+                        log::warn!("Unhandled m with unknown start: {:?} in {:?}", params, self.name)
                     }
                 }
             }
@@ -156,7 +156,7 @@ impl Perform for Renderer {
         } else if action == 'G' {
             self.set_column(params.get::<1>().map(|a| a[0]).unwrap_or(1));
         } else {
-            log::warn!("Unhandled dispatch {} {:?}", action, params);
+            log::warn!("Unhandled dispatch {} {:?} in {:?}", action, params, self.name);
         }
     }
 }

--- a/ansi-to-html/src/renderer.rs
+++ b/ansi-to-html/src/renderer.rs
@@ -2,6 +2,7 @@ use crate::ansi::Color;
 use std::collections::HashMap;
 
 pub struct Renderer {
+    pub name: String,
     pub bold: bool,
     pub italic: bool,
     pub underline: bool,
@@ -97,9 +98,10 @@ impl Default for Cell {
     }
 }
 
-impl Default for Renderer {
-    fn default() -> Self {
+impl Renderer {
+    pub fn new(name: String) -> Self {
         Self {
+            name,
             bold: false,
             italic: false,
             underline: false,
@@ -111,9 +113,7 @@ impl Default for Renderer {
             styles: Styles::default(),
         }
     }
-}
 
-impl Renderer {
     pub fn print(&mut self, c: char) {
         let cell = Cell {
             text: c,

--- a/src/render.rs
+++ b/src/render.rs
@@ -37,7 +37,8 @@ function scroll_to_ub() {{
 }
 
 pub fn render_crate(krate: &Crate, output: &str) -> String {
-    let (css, mut encoded) = ansi_to_html::convert_escaped(output);
+    let (css, mut encoded) =
+        ansi_to_html::convert_escaped(format!("{}/{}", krate.name, krate.version), output);
 
     // Remove blank rows from the bottom of the terminal output
     let ending = "\n</span>";


### PR DESCRIPTION
This is a way to hunt down what crate is emitting strange escape sequences and if I care.