### PR TITLE
Use more ASan features, and not cargo-careful

### DIFF
--- a/docker/Dockerfile-asan
+++ b/docker/Dockerfile-asan
@@ -4,8 +4,7 @@ ENV PATH=/root/.cargo/bin:$PATH
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- --default-toolchain=nightly --component=rust-src --profile=minimal -y && \
-    cargo install --git https://github.com/saethlin/miri-tools cargo-download && \
-    cargo install cargo-careful
+    cargo install --git https://github.com/saethlin/miri-tools cargo-download
 
 RUN apt-get update && \
     apt-get install -y clang lld expect && \

--- a/docker/run-asan.sh
+++ b/docker/run-asan.sh
@@ -2,8 +2,6 @@ exec 2>&1
 
 export TERM=xterm-256color
 
-cargo +nightly careful setup &> /dev/null
-
 while read crate;
 do
     cd /root/build
@@ -12,8 +10,8 @@ do
     then
         ARGS=$(python3 /root/get-args.py $crate)
         cargo +nightly update &> /dev/null
-        cargo +nightly careful test --no-run --jobs=1 $ARGS &> /dev/null
-        timeout --kill-after=10 600 unbuffer -p cargo +nightly careful test --jobs=1 --no-fail-fast $ARGS -- --test-threads=1
+        cargo +nightly test --no-run --jobs=1 $ARGS &> /dev/null
+        timeout --kill-after=10 600 unbuffer -p cargo +nightly test --color=always --jobs=1 --no-fail-fast $ARGS -- --test-threads=1
     fi
     echo "-${TEST_END_DELIMITER}-"
 done < /dev/stdin

--- a/src/run.rs
+++ b/src/run.rs
@@ -210,6 +210,8 @@ fn spawn_asan_worker(args: &Args, test_end_delimiter: &str) -> tokio::process::C
             "--env",
             &format!("RUSTDOCFLAGS={rust_flags}"),
             "--env",
+            "ASAN_OPTIONS=detect_stack_use_after_return=true:allocator_may_return_null=1:detect_invalid_pointer_pairs=2",
+            "--env",
             "CARGO_INCREMENTAL=0",
             "--env",
             "RUST_BACKTRACE=1",


### PR DESCRIPTION
With cargo-careful, the vast majority of the `/ub` page is uses of `mem::uninitialized` that are handled by the mitigation. We lose the careful sysroot because I really don't want to eat the cost of doing a `-Zbuild-std` on every build. So we have slightly less signal but WAY less noise with this setup.