### PR TITLE
Improve sandboxing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
         run: |
           cargo run -- sync --tool=miri --bucket=miri-bot-dev
-          cargo run -- run --tool=miri --crates=10 --bucket=miri-bot-dev
-          cargo run -- sync --tool=miri --bucket=miri-bot-dev
-          cargo run -- run --tool=asan --crates=10 --bucket=miri-bot-dev
+          cargo run -- run --tool=miri --bucket=miri-bot-dev --crate-list=ci-crates
           cargo run -- sync --tool=asan --bucket=miri-bot-dev
+          cargo run -- run --tool=asan --bucket=miri-bot-dev --crate-list=ci-crates
+          cargo run -- sync --tool=build --bucket=miri-bot-dev
+          cargo run -- run --tool=build --bucket=miri-bot-dev --crate-list=ci-crates

--- a/ci-crates
+++ b/ci-crates
@@ -1,0 +1,3 @@
+libc
+serde
+itoa

--- a/docker/Dockerfile-asan
+++ b/docker/Dockerfile-asan
@@ -1,7 +1,6 @@
 FROM ghcr.io/rust-lang/crates-build-env/linux
 
 ENV PATH=/root/.cargo/bin:$PATH
-
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- --default-toolchain=nightly --component=rust-src --profile=minimal -y && \
     cargo install --git https://github.com/saethlin/miri-tools cargo-download
@@ -14,5 +13,11 @@ COPY config.toml /root/.cargo/config.toml
 
 COPY get-args.py /root/
 COPY run-asan.sh /root/run.sh
+
+ENV RUSTFLAGS="-Zsanitizer=address --cap-lints=allow -Zrandomize-layout -Copt-level=0 -Cdebuginfo=1 -Zvalidate-mir"
+ENV RUSTDOCFLAGS=$RUSTFLAGS
+ENV ASAN_OPTIONS=detect_stack_use_after_return=true:allocator_may_return_null=1:detect_invalid_pointer_pairs=2
+ENV CARGO_INCREMENTAL=0
+ENV RUST_BACKTRACE=1
 
 ENTRYPOINT ["bash", "/root/run.sh"]

--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -1,27 +1,26 @@
 FROM ghcr.io/rust-lang/crates-build-env/linux
 
 ENV PATH=/root/.cargo/bin:$PATH
+ENV TOOLCHAIN=f2c6735504f9c1c0baa07ad5932d994d4c8be6db
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- --default-toolchain=nightly --component=miri --component=rust-src --profile=minimal -y && \
+    sh -s -- --default-toolchain=stable --profile=minimal -y && \
+    cargo install rustup-toolchain-install-master && \
     cargo install --git https://github.com/saethlin/miri-tools cargo-download && \
-    cargo install cargo-nextest
+    rustup-toolchain-install-master $TOOLCHAIN
 
 RUN apt-get update && \
     apt-get install -y clang lld expect && \
     rm -rf /var/lib/apt/lists/*
 
-COPY config.toml nextest.toml /root/.cargo/
+COPY config.toml /root/.cargo/config.toml
 
 COPY get-args.py /root/
-COPY run-miri.sh /root/run.sh
+COPY run-build.sh /root/run.sh
 
-ENV RUSTFLAGS="--cap-lints=allow -Zrandomize-layout -Copt-level=0 -Cdebuginfo=0 -Zvalidate-mir"
+ENV RUSTFLAGS="--cap-lints=allow -Zmir-opt-level=2 -Zinline-mir -Copt-level=0 -Cdebuginfo=1 -Zvalidate-mir"
 ENV RUSTDOCFLAGS=$RUSTFLAGS
-ENV MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-panic-on-unsupported"
 ENV CARGO_INCREMENTAL=0
 ENV RUST_BACKTRACE=1
-
-RUN cargo +nightly miri setup
 
 ENTRYPOINT ["bash", "/root/run.sh"]

--- a/docker/run-asan.sh
+++ b/docker/run-asan.sh
@@ -5,7 +5,8 @@ export TERM=xterm-256color
 while read crate;
 do
     cd /root/build
-    find /root/build /tmp -mindepth 1 -delete # clean out anything from an old build (probably)
+    # Delete everything in our writable mount points
+    find /root/build /tmp /root/.cargo/registry -mindepth 1 -delete
     if cargo download $crate /root/build
     then
         ARGS=$(python3 /root/get-args.py $crate)

--- a/docker/run-build.sh
+++ b/docker/run-build.sh
@@ -5,7 +5,8 @@ export TERM=xterm-256color
 while read crate;
 do
     cd /root/build
-    find /root/build /tmp -mindepth 1 -delete # clean out anything from an old build (probably)
+    # Delete everything in our writable mount points
+    find /root/build /tmp /root/.cargo/registry -mindepth 1 -delete
     if cargo download $crate /root/build
     then
         ARGS=$(python3 /root/get-args.py $crate)

--- a/docker/run-build.sh
+++ b/docker/run-build.sh
@@ -9,9 +9,7 @@ do
     if cargo download $crate /root/build
     then
         ARGS=$(python3 /root/get-args.py $crate)
-        cargo +nightly update &> /dev/null
-        cargo +nightly test --no-run --target=x86_64-unknown-linux-gnu $ARGS &> /dev/null
-        timeout --kill-after=10 600 unbuffer -p cargo +nightly test --color=always --no-fail-fast --target=x86_64-unknown-linux-gnu $ARGS
+        cargo +$TOOLCHAIN test --no-run --target=x86_64-unknown-linux-gnu $ARGS
     fi
     echo "-${TEST_END_DELIMITER}-"
 done < /dev/stdin

--- a/docker/run-miri.sh
+++ b/docker/run-miri.sh
@@ -7,7 +7,8 @@ cargo +nightly miri setup &> /dev/null
 while read crate;
 do
     cd /root/build
-    find /root/build /tmp -mindepth 1 -delete # clean out anything from an old build (probably)
+    # Delete everything in our writable mount points
+    find /root/build /tmp /root/.cargo/registry -mindepth 1 -delete
     if cargo download $crate /root/build
     then
         ARGS=$(python3 /root/get-args.py $crate)

--- a/docker/run-miri.sh
+++ b/docker/run-miri.sh
@@ -7,14 +7,14 @@ cargo +nightly miri setup &> /dev/null
 while read crate;
 do
     cd /root/build
-    find /root/build -mindepth 1 -delete # clean out anything from an old build (probably)
+    find /root/build /tmp -mindepth 1 -delete # clean out anything from an old build (probably)
     if cargo download $crate /root/build
     then
         ARGS=$(python3 /root/get-args.py $crate)
         cargo +nightly update &> /dev/null
-        cargo +nightly miri test --no-run --jobs=1 $ARGS &> /dev/null
-        MIRIFLAGS="$MIRIFLAGS --color=always" timeout --kill-after=10 3600 unbuffer -p cargo +nightly miri nextest run --color=always --no-fail-fast --config-file=/root/.cargo/nextest.toml --jobs=1 $ARGS
-        timeout --kill-after=10 600 unbuffer -p cargo +nightly miri test --doc --no-fail-fast --jobs=1 $ARGS
+        cargo +nightly miri test --no-run $ARGS &> /dev/null
+        timeout --kill-after=10 3600 unbuffer -p cargo +nightly miri nextest run --color=always --no-fail-fast --config-file=/root/.cargo/nextest.toml $ARGS
+        timeout --kill-after=10 600 unbuffer -p cargo +nightly miri test --doc --no-fail-fast $ARGS
     fi
     echo "-${TEST_END_DELIMITER}-"
 done < /dev/stdin

--- a/docker/run-miri.sh
+++ b/docker/run-miri.sh
@@ -14,7 +14,8 @@ do
         ARGS=$(python3 /root/get-args.py $crate)
         cargo +nightly update &> /dev/null
         cargo +nightly miri test --no-run $ARGS &> /dev/null
-        timeout --kill-after=10 3600 unbuffer -p cargo +nightly miri nextest run --color=always --no-fail-fast --config-file=/root/.cargo/nextest.toml $ARGS
+        # rustdoc is already passed --color=always, so adding it to the global MIRIFLAGS is just an error
+        MIRIFLAGS="$MIRIFLAGS --color=always" timeout --kill-after=10 3600 unbuffer -p cargo +nightly miri nextest run --color=always --no-fail-fast --config-file=/root/.cargo/nextest.toml $ARGS
         timeout --kill-after=10 600 unbuffer -p cargo +nightly miri test --doc --no-fail-fast $ARGS
     fi
     echo "-${TEST_END_DELIMITER}-"

--- a/docker/run-miri.sh
+++ b/docker/run-miri.sh
@@ -2,8 +2,6 @@ exec 2>&1
 
 export TERM=xterm-256color
 
-cargo +nightly miri setup &> /dev/null
-
 while read crate;
 do
     cd /root/build

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ fn main() -> Result<()> {
 pub enum Tool {
     Miri,
     Asan,
+    Build,
 }
 
 impl Tool {
@@ -50,6 +51,7 @@ impl Tool {
         match self {
             Tool::Miri => "miri/raw",
             Tool::Asan => "asan/raw",
+            Tool::Build => "build/raw",
         }
     }
 
@@ -61,6 +63,7 @@ impl Tool {
         match self {
             Tool::Miri => "miri/logs",
             Tool::Asan => "asan/logs",
+            Tool::Build => "build/logs",
         }
     }
 
@@ -72,6 +75,7 @@ impl Tool {
         match self {
             Tool::Miri => "miri/index.html",
             Tool::Asan => "asan/index.html",
+            Tool::Build => "build/index.html",
         }
     }
 }
@@ -81,6 +85,7 @@ impl fmt::Display for Tool {
         let s = match self {
             Tool::Miri => "miri",
             Tool::Asan => "asan",
+            Tool::Build => "build",
         };
         f.write_str(s)
     }
@@ -93,6 +98,7 @@ impl FromStr for Tool {
         match s {
             "miri" => Ok(Self::Miri),
             "asan" => Ok(Self::Asan),
+            "build" => Ok(Self::Build),
             _ => Err(format!("Invalid tool {}", s)),
         }
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -259,10 +259,17 @@ impl<'a> Worker<'a> {
                 "run",
                 "--rm",
                 "--interactive",
+                // Pin the build to a single CPU; this also ensures that anything doing
+                // make -j $(nproc)
+                // will not spawn processes appropriate for the host.
                 &format!("--cpuset-cpus={cpu}"),
+                // We set up our filesystem as read-only, but with 3 exceptions
                 "--read-only",
+                // The directory we are building in (not just its target dir!) is all writable
                 "--tmpfs=/root/build:exec",
+                // rustdoc tries to write to and executes files in /tmp, odd move but whatever
                 "--tmpfs=/tmp:exec",
+                // The default cargo registry location; we download dependences in the sandbox
                 "--tmpfs=/root/.cargo/registry",
                 &format!("--env=RUSTFLAGS={rustflags}"),
                 &format!("--env=RUSTDOCFLAGS={rustflags}"),


### PR DESCRIPTION
* Factor out all the boilerplate for launching the docker containers
* Add a build-only Tool
* Mount the whole filesystem as read-only, with tmpfs mounts for regions we need to write to
* Improve cleanup code to purge all the writable mount points
* Shift all the environment variables to the Dockerfiles to do cargo miri setup pre-sandbox