### PR TITLE
Pass through terminal/window params

### DIFF
--- a/inapty/Cargo.lock
+++ b/inapty/Cargo.lock
@@ -3,7 +3,7 @@
 version = 3
 
 [[package]]
-name = "inatty"
+name = "inapty"
 version = "0.1.0"
 dependencies = [
  "libc",


### PR DESCRIPTION
It looks like nextest does some very strange things if you don't pass through a window size and terminal settings. Hard to blame anyone but me for that, if you don't set these you get a terminal with width and height 0.