### PR TITLE
Set a reasonable window size for inapty

### DIFF
--- a/inapty/src/main.rs
+++ b/inapty/src/main.rs
@@ -5,36 +5,17 @@ use std::process::Command;
 use std::ptr;
 
 fn main() {
+    let winsz = libc::winsize {
+        ws_col: 256,
+        ws_row: 64,
+        ws_xpixel: 2560,
+        ws_ypixel: 1408,
+    };
+
     let mut pty: i32 = 0;
 
-    let mut termios = libc::termios {
-        c_iflag: 0,
-        c_oflag: 0,
-        c_cflag: 0,
-        c_lflag: 0,
-        c_line: 0,
-        c_cc: [0; 32],
-        c_ispeed: 0,
-        c_ospeed: 0,
-    };
-    // SAFETY: Out param is a valid pointer to the right type
-    unsafe {
-        libc::tcgetattr(0, &mut termios);
-    }
-
-    let mut winsz = libc::winsize {
-        ws_col: 0,
-        ws_row: 0,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    // SAFETY: Out param is a valid pointer to the right type
-    unsafe {
-        libc::ioctl(0, libc::TIOCGWINSZ, &mut winsz);
-    }
-
     // SAFETY: Pointer arguments are valid (and thus ignored) or null
-    let pid = unsafe { libc::forkpty(&mut pty, ptr::null_mut(), &termios, &winsz) };
+    let pid = unsafe { libc::forkpty(&mut pty, ptr::null_mut(), ptr::null_mut(), &winsz) };
 
     if pid == 0 {
         // We are the child. Spawn the subprocess based off our arguments.


### PR DESCRIPTION
If the parent wasn't connected to a TTY, the previous code already did nothing useful. Now at least we always set a reasonable window size.