### PR TITLE
Use cargo-careful for --tool=asan, without strict init checks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y curl build-essential && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- --default-toolchain=nightly --component=miri --component=rust-src --profile=minimal -y && \
     cargo install --git https://github.com/saethlin/miri-tools cargo-download inapty get-args && \
+    cargo install cargo-careful && \
     curl -L https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.54/cargo-nextest-0.9.54-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /root/.cargo/bin/ && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -15,7 +15,7 @@ elif [[ $TOOL == "asan" ]]; then
     # We really want to only run out of stack in true infinite recursion.
     ulimit -s 1048576
     export RUST_MIN_STACK=1073741824
-    export RUSTFLAGS="$RUSTFLAGS -Zsanitizer=address -Cdebuginfo=1"
+    export RUSTFLAGS="$RUSTFLAGS -Cdebuginfo=1 -Zstrict-init-checks=no"
     export ASAN_OPTIONS="detect_stack_use_after_return=true:allocator_may_return_null=1:detect_invalid_pointer_pairs=2"
 elif [[ $TOOL == "miri" ]]; then
     export RUSTFLAGS="$RUSTFLAGS -Zrandomize-layout -Cdebuginfo=0"
@@ -32,8 +32,8 @@ function run_build {
 }
 
 function run_asan {
-    cargo +$TOOLCHAIN test --no-run --target=$HOST $ARGS &> /dev/null
-    timeout --kill-after=10 600 inapty cargo +$TOOLCHAIN test --color=always --no-fail-fast --target=$HOST $ARGS
+    cargo +$TOOLCHAIN careful test -Zcareful-sanitizer=address --no-run --target=$HOST $ARGS &> /dev/null
+    timeout --kill-after=10 600 inapty cargo +$TOOLCHAIN careful test -Zcareful-sanitizer=address --color=always --no-fail-fast --target=$HOST $ARGS
 }
 
 function run_miri {


### PR DESCRIPTION
With `-Zstrict-init-checks=yes`, most of the reports from this tool end up being the strict init checks. The point of ASan is to find _exciting_ bugs, and bugs that we have an effective mitigation for are not exciting.

We of course still want cargo-careful for the ASan-enabled sysroot.