### PR TITLE
Render logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-           cargo install ansi-to-html inapty --locked --git https://github.com/saethlin/miri-tools
-           inapty bash ci.sh ${{ matrix.suite }} | tee /dev/stderr 2> >(ansi-to-html > output.html)
-           aws s3 cp output.html s3://miri-bot-dev/${GITHUB_REPOSITORY}/${GITHUB_RUN_ID}/${{ matrix.suite }}.html
+          echo "::group::Install dependencies"
+          cargo install ansi-to-html inapty --locked --git https://github.com/saethlin/miri-tools
+          echo "::endgroup"
+          inapty bash ci.sh ${{ matrix.suite }} | tee /dev/stderr 2> >(ansi-to-html > output.html)
+          aws s3 cp output.html s3://miri-bot-dev/${GITHUB_REPOSITORY}/${GITHUB_RUN_ID}/${{ matrix.suite }}.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,36 +9,20 @@ on:
 name: CI
 
 jobs:
-  style:
+  suite_matrix:
+    strategy:
+      matrix:
+        suite: [style, miri, asan, build]
     runs-on: ubuntu-latest
-    name: Style Checks
+    name: Test ${{ matrix.suite }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install toolchain
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-      - name: Style
-        run: |
-          cargo fmt --check
-          cargo clippy -- -Dclippy::all
-
-  test:
-    runs-on: ubuntu-latest
-    name: Test
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
       - name: Run
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          cargo run -- sync --tool=miri --bucket=miri-bot-dev
-          cargo run -- run --tool=miri --bucket=miri-bot-dev --crate-list=ci-crates
-          cargo run -- sync --tool=asan --bucket=miri-bot-dev
-          cargo run -- run --tool=asan --bucket=miri-bot-dev --crate-list=ci-crates
-          cargo run -- sync --tool=build --bucket=miri-bot-dev
-          cargo run -- run --tool=build --bucket=miri-bot-dev --crate-list=ci-crates
+           cargo install ansi-to-html inapty --locked --git https://github.com/saethlin/miri-tools
+           inapty bash ci.sh ${{ matrix.suite }} | tee /dev/stderr 2> >(ansi-to-html > output.html)
+           aws s3 cp output.html s3://miri-bot-dev/${GITHUB_REPOSITORY}/${GITHUB_RUN_ID}/${{ matrix.suite }}.html

--- a/ci.sh
+++ b/ci.sh
@@ -42,7 +42,8 @@ rustup update
 
 endgroup
 
-if $1 -ne "style" then
+if $1 -ne "style"
+then
     begingroup cargo build
     cargo build
     endgroup

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+exec 2>&1
+export TERM=xterm-256color
+
+function style() {
+    cargo fmt --check
+    cargo clippy -- -Dclippy::all
+}
+
+function miri() {
+    cargo run -- sync --tool=miri --bucket=miri-bot-dev
+    cargo run -- run --tool=miri --bucket=miri-bot-dev --crate-list=ci-crates --rerun
+}
+
+function asan() {
+    cargo run -- sync --tool=asan --bucket=miri-bot-dev
+    cargo run -- run --tool=asan --bucket=miri-bot-dev --crate-list=ci-crates --rerun
+}
+
+function build() {
+    cargo run -- sync --tool=build --bucket=miri-bot-dev
+    cargo run -- run --tool=build --bucket=miri-bot-dev --crate-list=ci-crates --rerun
+}
+
+rustup self update
+rustup default stable
+rustup update
+
+$1

--- a/ci.sh
+++ b/ci.sh
@@ -4,6 +4,16 @@ set -e
 exec 2>&1
 export TERM=xterm-256color
 
+function begingroup {
+    echo "::group::$@"
+    set -x
+}
+
+function endgroup {
+    set +x
+    echo "::endgroup"
+}
+
 function style() {
     cargo fmt --check
     cargo clippy -- -Dclippy::all
@@ -24,8 +34,18 @@ function build() {
     cargo run -- run --tool=build --bucket=miri-bot-dev --crate-list=ci-crates --rerun
 }
 
+begingroup Update toolchain
+
 rustup self update
 rustup default stable
 rustup update
+
+endgroup
+
+if $1 -ne "style" then
+    begingroup cargo build
+    cargo build
+    endgroup
+fi
 
 $1

--- a/ci.sh
+++ b/ci.sh
@@ -6,11 +6,9 @@ export TERM=xterm-256color
 
 function begingroup {
     echo "::group::$@"
-    set -x
 }
 
 function endgroup {
-    set +x
     echo "::endgroup"
 }
 
@@ -42,11 +40,13 @@ rustup update
 
 endgroup
 
-if $1 -ne "style"
+if "$1" -ne "style"
 then
     begingroup cargo build
     cargo build
     endgroup
 fi
 
+begingroup "Test" $1
 $1
+endgroup

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,0 +1,6 @@
+FROM ghcr.io/saethlin/crater-at-home-ci:latest
+
+COPY nextest.toml /root/.cargo/nextest.toml
+COPY run.sh /root/run.sh
+
+ENTRYPOINT ["bash", "/root/run.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,3 +5,4 @@ set -eu
 docker run --rm --privileged tonistiigi/binfmt:latest --install all
 docker buildx create --driver docker-container --use
 docker buildx build --file ./Dockerfile.base --platform linux/amd64,linux/arm64 --tag ghcr.io/saethlin/crates-build-env:latest --push .
+docker buildx build --file ./Dockerfile.ci-base --platform linux/amd64,linux/arm64 --tag ghcr.io/saethlin/crater-at-home-ci:latest --push .

--- a/src/run.rs
+++ b/src/run.rs
@@ -81,15 +81,13 @@ async fn build_crate_list(args: &Args, client: &Client) -> Result<Vec<Crate>> {
 
 #[tokio::main]
 pub async fn run(args: Args) -> Result<()> {
+    let dockerfile = if std::env::var_os("CI").is_some() {
+        "docker/Dockerfile.ci"
+    } else {
+        "docker/Dockerfile"
+    };
     let status = std::process::Command::new("docker")
-        .args([
-            "build",
-            "-t",
-            "crater-at-home",
-            "-f",
-            "docker/Dockerfile",
-            "docker/",
-        ])
+        .args(["build", "-t", "crater-at-home", "-f", dockerfile, "docker/"])
         .status()?;
     color_eyre::eyre::ensure!(status.success(), "docker image build failed!");
 


### PR DESCRIPTION
I wrote this tool to render nice HTML from terminal output.
The GitHub viewer for CI logs is terrible; the rendered HTML pages from this project are smaller and load vastly faster because we actually handle terminal escapes correctly and we emit significantly less DOM elements.

Log group handling and an easy way to get to the uploaded logs is still TBD but this is already enormously better.