### PR TITLE
Change build dir to /build not /root/build

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -39,7 +39,6 @@ function run_asan {
 }
 
 function run_miri {
-    cargo +$TOOLCHAIN miri setup
     timed cargo +$TOOLCHAIN miri test --no-run $ARGS &> /dev/null
     # rustdoc is already passed --color=always, so adding it to the global MIRIFLAGS is just an error
     MIRIFLAGS="$MIRIFLAGS --color=always" timed inapty cargo +$TOOLCHAIN miri nextest run --color=always --no-fail-fast --config-file=/root/.cargo/nextest.toml $ARGS
@@ -52,10 +51,10 @@ fi
 
 while read crate;
 do
-    cd /root/build
+    cd /build
     # Delete everything in our writable mount points
-    find /root/build /tmp /root/.cargo/registry -mindepth 1 -delete
-    if cargo download $crate /root/build; then 
+    find /build /tmp /root/.cargo/registry -mindepth 1 -delete
+    if cargo download $crate /build; then
         ARGS=$(get-args $crate)
         cargo +$TOOLCHAIN update &> /dev/null
         if [[ $TOOL == "build" ]]; then

--- a/src/diagnose.rs
+++ b/src/diagnose.rs
@@ -168,9 +168,9 @@ fn diagnose_output(output: &str) -> Vec<Cause> {
         for line in &lines[l..] {
             if line.contains("inside `") && line.contains(" at ") {
                 let path = line.split(" at ").nth(1).unwrap();
-                if path.contains("/root/build") || !path.starts_with('/') {
+                if path.starts_with("/build") || !path.starts_with('/') {
                     break;
-                } else if path.contains("/root/.cargo/registry/src/") {
+                } else if path.contains(".cargo/registry/src/") {
                     let crate_name = path.split('/').nth(6).unwrap();
                     source_crate = Some(crate_name.to_string());
                     break;

--- a/src/run.rs
+++ b/src/run.rs
@@ -191,18 +191,13 @@ fn spawn_worker(args: &Args, cpu: usize) -> tokio::process::Child {
         // We set up our filesystem as read-only, but with 3 exceptions
         "--read-only",
         // The directory we are building in (not just its target dir!) is all writable
-        "--tmpfs=/root/build:exec",
+        "--tmpfs=/build:exec",
         // rustdoc tries to write to and executes files in /tmp, odd move but whatever
         "--tmpfs=/tmp:exec",
         // The default cargo registry location; we download dependences in the sandbox
         "--tmpfs=/root/.cargo/registry:exec",
         // cargo-miri builds a sysroot under /root/.cache, so why not make it all writeable
         "--tmpfs=/root/.cache:exec",
-        // AWS credentials for sccache
-        &format!(
-            "--volume={}/.aws:/root/.aws:ro",
-            dirs::home_dir().unwrap().display()
-        ),
         &format!("--env=TEST_END_DELIMITER={}", *TEST_END_DELIMITER),
         &format!("--env=TOOL={}", args.tool),
     ]);


### PR DESCRIPTION
This shortens up some paths in general which is nice, and also means that crates which attempt to reach too far outside of the crate will fail faster.